### PR TITLE
fix: support OpenAI models on Amazon Bedrock (GPT-5.5 via /responses)

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -280,8 +280,12 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 		if !hasReasoningEffort && model.ModelCfg.ReasoningEffort != "" && model.CatwalkCfg.CanReason {
 			mergedOptions["reasoning_effort"] = model.ModelCfg.ReasoningEffort
 		}
-		if openai.IsResponsesModel(model.CatwalkCfg.ID) {
-			if openai.IsResponsesReasoningModel(model.CatwalkCfg.ID) {
+		modelIDForResponses := model.CatwalkCfg.ID
+		if !openai.IsResponsesModel(modelIDForResponses) {
+			modelIDForResponses = strings.TrimPrefix(modelIDForResponses, "openai.")
+		}
+		if openai.IsResponsesModel(modelIDForResponses) {
+			if openai.IsResponsesReasoningModel(modelIDForResponses) {
 				mergedOptions["reasoning_summary"] = "auto"
 				mergedOptions["include"] = []openai.IncludeType{openai.IncludeReasoningEncryptedContent}
 			}
@@ -689,6 +693,10 @@ func (c *coordinator) buildOpenaiProvider(baseURL, apiKey string, headers map[st
 	opts := []openai.Option{
 		openai.WithAPIKey(apiKey),
 		openai.WithUseResponsesAPI(),
+		openai.WithResponsesAPIFunc(func(modelID string) bool {
+			return openai.IsResponsesModel(modelID) ||
+				openai.IsResponsesModel(strings.TrimPrefix(modelID, "openai."))
+		}),
 	}
 	if c.cfg.Config().Options.Debug {
 		httpClient := log.NewHTTPClient()

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -311,7 +311,7 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 				prepared.ExtraParams["region"] = env.Get("AWS_DEFAULT_REGION")
 			}
 			for _, model := range p.Models {
-				if !strings.HasPrefix(model.ID, "anthropic.") {
+				if !strings.Contains(model.ID, "anthropic.") {
 					return fmt.Errorf("bedrock provider only supports anthropic models for now, found: %s", model.ID)
 				}
 			}


### PR DESCRIPTION
## Summary

Adds support for running OpenAI models (e.g. GPT-5.5) served through
Amazon Bedrock's OpenAI-compatible endpoint
(`https://bedrock-mantle.<region>.api.aws/openai/v1`), configured as a
custom `type: "openai"` provider.

Two issues blocked this:

- **Responses API was never selected.** Bedrock requires the model ID
  `openai.gpt-5.5`, but `openai.IsResponsesModel` does an exact-match
  against an allowlist that only contains the bare `gpt-5.5`. The
  mismatch caused the SDK to fall back to `/v1/chat/completions`, which
  the model rejects: `The model 'openai.gpt-5.5' does not support the
  '/v1/chat/completions' API`. Bedrock also rejects the bare `gpt-5.5`
  (`model does not exist`), so the prefix can't simply be dropped in
  config. We now strip the `openai.` Bedrock prefix when testing the
  Responses allowlist, in both `buildOpenaiProvider`
  (`WithResponsesAPIFunc`) and the provider-options path.

- **Native Bedrock validation rejected regional inference profiles.**
  `configureProviders` required model IDs to start with `anthropic.`,
  which excludes the standard regional profile IDs like
  `us.anthropic.claude-...`. Relaxed to `strings.Contains`.

## Testing

- `go build ./...`, `go vet ./internal/...` clean.
- Verified end-to-end against `bedrock-mantle.us-east-2` with a Bedrock
  API key: GPT-5.5 now routes to `/responses` and returns completions.
- Existing Bedrock (Anthropic) providers with `us.`/`eu.` regional
  prefixes load without the spurious validation error.

## Notes

A cleaner long-term fix would make `IsResponsesModel` provider-aware
upstream in `fantasy` rather than stripping the prefix at the call
site; happy to follow up there if preferred.