### PR TITLE
Feat: Image Rendering Using Kitty Graphics Protocol

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -166,6 +166,8 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		return nil, ErrSessionMissing
 	}
 
+	call.Attachments = normalizeImageAttachments(call.Attachments)
+
 	// Queue the message if busy
 	if a.IsSessionBusy(call.SessionID) {
 		existing, ok := a.messageQueue.Get(call.SessionID)

--- a/internal/agent/image.go
+++ b/internal/agent/image.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"bytes"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"log/slog"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/disintegration/imaging"
+	_ "golang.org/x/image/webp"
+)
+
+const (
+	maxImageBytes     = 3_500_000
+	maxImageDimension = 1568
+)
+
+// normalizeImageAttachments downscales oversized image attachments in place and
+// returns the same slice. Clipboard pastes in particular arrive as lossless
+// PNGs that balloon well past provider limits.
+func normalizeImageAttachments(attachments []message.Attachment) []message.Attachment {
+	for i, att := range attachments {
+		if !att.IsImage() || len(att.Content) <= maxImageBytes {
+			continue
+		}
+
+		data, err := shrinkImage(att.Content)
+
+		if err != nil {
+			slog.Warn("Failed to shrink oversized image attachment, sending as-is", "file", att.FileName, "bytes", len(att.Content), "error", err)
+			continue
+		}
+
+		if len(data) > maxImageBytes {
+			slog.Warn("Image still exceeds budget after downscaling", "file", att.FileName, "bytes", len(data))
+		}
+
+		slog.Debug("Shrank oversized image attachment", "file", att.FileName, "before", len(att.Content), "after", len(data))
+		attachments[i].Content = data
+		attachments[i].MimeType = "image/jpeg"
+	}
+	return attachments
+}
+
+// shrinkImage fits the image within maxImageDimension and re-encodes it as
+// JPEG, lowering quality until the result fits within maxImageBytes. If no
+// quality step fits, it returns the smallest encoding as a best effort.
+func shrinkImage(data []byte) ([]byte, error) {
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	img = imaging.Fit(img, maxImageDimension, maxImageDimension, imaging.Lanczos)
+
+	var smallest []byte
+	for _, quality := range []int{85, 70, 55, 40} {
+		var buf bytes.Buffer
+
+		if err := imaging.Encode(&buf, img, imaging.JPEG, imaging.JPEGQuality(quality)); err != nil {
+			return nil, err
+		}
+
+		smallest = buf.Bytes()
+
+		if len(smallest) <= maxImageBytes {
+			return smallest, nil
+		}
+	}
+	return smallest, nil
+}

--- a/internal/agent/image_test.go
+++ b/internal/agent/image_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/png"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+// bigPNG builds a large, noisy PNG that exceeds maxImageBytes, mimicking a
+// clipboard-pasted photo re-encoded losslessly. Noise is incompressible, so
+// the encoded result stays comfortably over the budget.
+func bigPNG(t *testing.T) []byte {
+	t.Helper()
+	const (
+		dim  = 1024
+		seed = 1
+	)
+	rng := rand.New(rand.NewPCG(seed, ^uint64(seed)))
+	img := image.NewRGBA(image.Rect(0, 0, dim, dim))
+
+	for i := 0; i+8 <= len(img.Pix); i += 8 {
+		binary.LittleEndian.PutUint64(img.Pix[i:], rng.Uint64())
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	require.Greater(t, buf.Len(), maxImageBytes, "fixture must exceed budget")
+	return buf.Bytes()
+}
+
+func TestNormalizeImageAttachments_ShrinksOversizedImage(t *testing.T) {
+	t.Parallel()
+
+	data := bigPNG(t)
+	atts := []message.Attachment{
+		{FileName: "IMG_0400.png", MimeType: "image/png", Content: data},
+	}
+
+	out := normalizeImageAttachments(atts)
+
+	require.Len(t, out, 1)
+	require.LessOrEqual(t, len(out[0].Content), maxImageBytes)
+	require.Equal(t, "image/jpeg", out[0].MimeType)
+	_, _, err := image.Decode(bytes.NewReader(out[0].Content))
+	require.NoError(t, err)
+}
+
+func TestNormalizeImageAttachments_LeavesSmallAndNonImages(t *testing.T) {
+	t.Parallel()
+
+	small := []byte("not really an image but small")
+	text := []byte("hello")
+	atts := []message.Attachment{
+		{FileName: "tiny.png", MimeType: "image/png", Content: small},
+		{FileName: "notes.txt", MimeType: "text/plain", Content: text},
+	}
+
+	out := normalizeImageAttachments(atts)
+
+	require.Equal(t, small, out[0].Content)
+	require.Equal(t, "image/png", out[0].MimeType)
+	require.Equal(t, text, out[1].Content)
+}
+
+func TestNormalizeImageAttachments_UndecodableImageSentAsIs(t *testing.T) {
+	t.Parallel()
+
+	garbage := bytes.Repeat([]byte{0xff}, maxImageBytes+1)
+	atts := []message.Attachment{
+		{FileName: "broken.png", MimeType: "image/png", Content: garbage},
+	}
+
+	out := normalizeImageAttachments(atts)
+
+	require.Equal(t, garbage, out[0].Content)
+	require.Equal(t, "image/png", out[0].MimeType)
+}
+
+func TestShrinkImage_BestEffortWhenOverBudget(t *testing.T) {
+	t.Parallel()
+
+	out, err := shrinkImage(bigPNG(t))
+
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+	_, _, err = image.Decode(bytes.NewReader(out))
+	require.NoError(t, err)
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -311,7 +311,7 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 				prepared.ExtraParams["region"] = env.Get("AWS_DEFAULT_REGION")
 			}
 			for _, model := range p.Models {
-				if !strings.HasPrefix(model.ID, "anthropic.") {
+				if !strings.HasPrefix(model.ID, "anthropic.") && !strings.Contains(model.ID, ".anthropic.") {
 					return fmt.Errorf("bedrock provider only supports anthropic models for now, found: %s", model.ID)
 				}
 			}

--- a/internal/ui/chat/docker_mcp.go
+++ b/internal/ui/chat/docker_mcp.go
@@ -144,7 +144,7 @@ func (d *DockerMCPToolRenderContext) RenderTool(sty *styles.Styles, width int, o
 
 	// Handle image content.
 	if opts.Result.Data != "" && strings.HasPrefix(opts.Result.MIMEType, "image/") {
-		parts = append(parts, "", toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
+		parts = append(parts, "", toolOutputImageContent(sty, opts.ToolCall.ID, opts.Result.Data, opts.Result.MIMEType, opts.ImageConfig))
 	}
 
 	if len(parts) == 0 {

--- a/internal/ui/chat/file.go
+++ b/internal/ui/chat/file.go
@@ -71,7 +71,7 @@ func (v *ViewToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *
 
 	// Handle image content.
 	if opts.Result.Data != "" && strings.HasPrefix(opts.Result.MIMEType, "image/") {
-		body := toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType)
+		body := toolOutputImageContent(sty, opts.ToolCall.ID, opts.Result.Data, opts.Result.MIMEType, opts.ImageConfig)
 		return joinToolParts(header, body)
 	}
 

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -64,7 +64,7 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 
 	if opts.Result.Data != "" && strings.HasPrefix(opts.Result.MIMEType, "image/") {
-		body := sty.Tool.Body.Render(toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
+		body := toolOutputImageContent(sty, opts.ToolCall.ID, opts.Result.Data, opts.Result.MIMEType, opts.ImageConfig)
 		return joinToolParts(header, body)
 	}
 

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -1,8 +1,14 @@
 package chat
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
 	"path/filepath"
 	"strings"
 	"time"
@@ -19,9 +25,11 @@ import (
 	"github.com/charmbracelet/crush/internal/stringext"
 	"github.com/charmbracelet/crush/internal/ui/anim"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	fimage "github.com/charmbracelet/crush/internal/ui/image"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
+	_ "golang.org/x/image/webp" // WebP decoding.
 )
 
 // responseContextHeight limits the number of lines displayed in tool output.
@@ -29,6 +37,11 @@ const responseContextHeight = 10
 
 // toolBodyLeftPaddingTotal represents the padding that should be applied to each tool body
 const toolBodyLeftPaddingTotal = 2
+
+const (
+	defaultImageCols = 60
+	defaultImageRows = 20
+)
 
 // ToolStatus represents the current state of a tool call.
 type ToolStatus int
@@ -52,6 +65,8 @@ type ToolMessageItem interface {
 	SetMessageID(id string)
 	SetStatus(status ToolStatus)
 	Status() ToolStatus
+	SetImageConfig(cfg *ImageConfig)
+	TransmitImage() tea.Cmd
 }
 
 // Compactable is an interface for tool items that can render in a compacted mode.
@@ -98,6 +113,17 @@ type ToolRenderOpts struct {
 	Compact         bool
 	IsSpinning      bool
 	Status          ToolStatus
+	ImageConfig     *ImageConfig
+}
+
+// ImageConfig holds configuration for inline image rendering.
+type ImageConfig struct {
+	Encoding   fimage.Encoding
+	CellWidth  int
+	CellHeight int
+	Tmux       bool
+	MaxCols    int
+	MaxRows    int
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -158,6 +184,9 @@ type baseToolMessageItem struct {
 	sty             *styles.Styles
 	anim            *anim.Anim
 	expandedContent bool
+
+	// imageConfig holds configuration for inline image rendering.
+	imageConfig *ImageConfig
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -333,6 +362,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 			Compact:         t.isCompact,
 			IsSpinning:      t.isSpinning(),
 			Status:          t.computeStatus(),
+			ImageConfig:     t.imageConfig,
 		})
 
 		// Prepend hook indicator if hooks ran for this tool call.
@@ -433,6 +463,45 @@ func (t *baseToolMessageItem) SetStatus(status ToolStatus) {
 // Status returns the current tool status.
 func (t *baseToolMessageItem) Status() ToolStatus {
 	return t.status
+}
+
+// SetImageConfig sets the image rendering configuration.
+func (t *baseToolMessageItem) SetImageConfig(cfg *ImageConfig) {
+	t.imageConfig = cfg
+}
+
+// TransmitImage transmits the image data to the terminal if the result contains
+// an image and the terminal supports inline image rendering.
+func (t *baseToolMessageItem) TransmitImage() tea.Cmd {
+	if t.result == nil || t.imageConfig == nil {
+		return nil
+	}
+	if t.result.Data == "" || !strings.HasPrefix(t.result.MIMEType, "image/") {
+		return nil
+	}
+	if t.imageConfig.Encoding != fimage.EncodingKitty {
+		return nil
+	}
+
+	data, err := base64.StdEncoding.DecodeString(t.result.Data)
+	if err != nil {
+		return nil
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil
+	}
+
+	cols, rows := imageRenderDims(t.imageConfig)
+
+	id := t.toolCall.ID
+	cs := fimage.CellSize{
+		Width:  t.imageConfig.CellWidth,
+		Height: t.imageConfig.CellHeight,
+	}
+
+	return t.imageConfig.Encoding.Transmit(id, img, cs, cols, rows, t.imageConfig.Tmux)
 }
 
 // computeStatus computes the effective status considering the result.
@@ -699,10 +768,40 @@ func toolOutputCodeContent(sty *styles.Styles, path, content string, offset, wid
 	return sty.Tool.Body.Render(strings.Join(out, "\n"))
 }
 
-// toolOutputImageContent renders image data with size info.
-func toolOutputImageContent(sty *styles.Styles, data, mediaType string) string {
+// imageRenderDims returns the column/row budget for inline image rendering.
+// Transmit and render must use identical dimensions, else the cache key never
+// matches and the image falls back to a chip.
+func imageRenderDims(cfg *ImageConfig) (cols, rows int) {
+	cols, rows = cfg.MaxCols, cfg.MaxRows
+	if cols <= 0 {
+		cols = defaultImageCols
+	}
+	if rows <= 0 {
+		rows = defaultImageRows
+	}
+	return cols, rows
+}
+
+// toolOutputImageContent renders image data inline when supported, otherwise
+// as a text summary.
+func toolOutputImageContent(sty *styles.Styles, toolCallID, data, mediaType string, imgCfg *ImageConfig) string {
 	dataSize := len(data) * 3 / 4
 	sizeStr := formatSize(dataSize)
+
+	if imgCfg != nil && imgCfg.Encoding == fimage.EncodingKitty {
+		cols, rows := imageRenderDims(imgCfg)
+
+		if fimage.HasTransmitted(toolCallID, cols, rows) {
+			imgRender := imgCfg.Encoding.Render(toolCallID, cols, rows)
+			infoLine := fmt.Sprintf(
+				"%s %s %s",
+				sty.Tool.MediaType.Render(mediaType),
+				sty.Tool.ResourceLoadedIndicator.Render(styles.ArrowRightIcon),
+				sty.Tool.ResourceSize.Render(sizeStr),
+			)
+			return sty.Tool.Body.Render(imgRender + "\n" + infoLine)
+		}
+	}
 
 	return sty.Tool.Body.Render(fmt.Sprintf(
 		"%s %s %s %s",

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -1,6 +1,12 @@
 package chat
 
 import (
+	"bytes"
+	"image"
+	_ "image/gif"  // GIF decoding.
+	_ "image/jpeg" // JPEG decoding.
+	_ "image/png"  // PNG decoding.
+	"os"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -8,8 +14,10 @@ import (
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	fimage "github.com/charmbracelet/crush/internal/ui/image"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	_ "golang.org/x/image/webp" // WebP decoding.
 )
 
 // UserMessageItem represents a user message in the chat UI.
@@ -22,6 +30,7 @@ type UserMessageItem struct {
 	attachments *attachments.Renderer
 	message     *message.Message
 	sty         *styles.Styles
+	imageConfig *ImageConfig
 }
 
 // NewUserMessageItem creates a new UserMessageItem.
@@ -119,16 +128,107 @@ func (m *UserMessageItem) ID() string {
 	return m.message.ID
 }
 
-// renderAttachments renders attachments.
+// renderAttachments renders attachments. If inline image rendering is supported,
+// images are rendered inline; otherwise they are shown as filename chips.
 func (m *UserMessageItem) renderAttachments(width int) string {
-	var attachments []message.Attachment
-	for _, at := range m.message.BinaryContent() {
-		attachments = append(attachments, message.Attachment{
+	binaryContents := m.message.BinaryContent()
+	if len(binaryContents) == 0 {
+		return ""
+	}
+
+	var parts []string
+
+	if m.imageConfig != nil && m.imageConfig.Encoding == fimage.EncodingKitty {
+		for _, bc := range binaryContents {
+			if !strings.HasPrefix(bc.MIMEType, "image/") {
+				continue
+			}
+			cols, rows := imageRenderDims(m.imageConfig)
+
+			if fimage.HasTransmitted(bc.Path, cols, rows) {
+				imgRender := m.imageConfig.Encoding.Render(bc.Path, cols, rows)
+				parts = append(parts, imgRender)
+			}
+		}
+	}
+
+	var attachmentList []message.Attachment
+	for _, at := range binaryContents {
+		attachmentList = append(attachmentList, message.Attachment{
 			FileName: at.Path,
 			MimeType: at.MIMEType,
 		})
 	}
-	return m.attachments.Render(attachments, false, width)
+	chips := m.attachments.Render(attachmentList, false, width)
+	if chips != "" {
+		parts = append(parts, chips)
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+// SetImageConfig sets the image rendering configuration.
+func (m *UserMessageItem) SetImageConfig(cfg *ImageConfig) {
+	m.imageConfig = cfg
+}
+
+// TransmitImages transmits any image attachments to the terminal for inline
+// rendering. Returns a tea.Cmd if images need to be transmitted.
+func (m *UserMessageItem) TransmitImages() tea.Cmd {
+	if m.imageConfig == nil || m.imageConfig.Encoding != fimage.EncodingKitty {
+		return nil
+	}
+
+	var cmds []tea.Cmd
+	for _, bc := range m.message.BinaryContent() {
+		if !strings.HasPrefix(bc.MIMEType, "image/") {
+			continue
+		}
+
+		cols, rows := imageRenderDims(m.imageConfig)
+
+		if fimage.HasTransmitted(bc.Path, cols, rows) {
+			continue
+		}
+
+		var img image.Image
+		var err error
+		if len(bc.Data) > 0 {
+			img, _, err = image.Decode(bytes.NewReader(bc.Data))
+		} else if bc.Path != "" {
+			img, err = loadImageFromFile(bc.Path)
+		}
+		if err != nil || img == nil {
+			continue
+		}
+
+		cs := fimage.CellSize{
+			Width:  m.imageConfig.CellWidth,
+			Height: m.imageConfig.CellHeight,
+		}
+
+		cmd := m.imageConfig.Encoding.Transmit(bc.Path, img, cs, cols, rows, m.imageConfig.Tmux)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+// loadImageFromFile loads an image from a file path.
+func loadImageFromFile(path string) (image.Image, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	img, _, err := image.Decode(f)
+	return img, err
 }
 
 // HandleKeyEvent implements KeyEventHandler.

--- a/internal/ui/common/common.go
+++ b/internal/ui/common/common.go
@@ -17,6 +17,11 @@ import (
 // MaxAttachmentSize defines the maximum allowed size for file attachments (5 MB).
 const MaxAttachmentSize = int64(5 * 1024 * 1024)
 
+// MaxImageAttachmentSize is the upper bound for image attachments before
+// downscaling. Images above MaxAttachmentSize are accepted and shrunk to fit
+// provider limits; this only guards against loading absurdly large files.
+const MaxImageAttachmentSize = int64(50 * 1024 * 1024)
+
 // AllowedImageTypes defines the permitted image file types.
 var AllowedImageTypes = []string{".jpg", ".jpeg", ".png"}
 

--- a/internal/ui/image/image.go
+++ b/internal/ui/image/image.go
@@ -61,6 +61,11 @@ type CellSize struct {
 type cachedImage struct {
 	img        image.Image
 	cols, rows int
+	// fitCols and fitRows are the image's cell footprint after the
+	// aspect-preserving fit. Using them (rather than cols/rows) for the kitty
+	// placement and placeholder grid renders the image flush-left instead of
+	// letterboxed inside the full box.
+	fitCols, fitRows int
 }
 
 var (
@@ -76,10 +81,12 @@ func ResetCache() {
 }
 
 // fitImage resizes the image to fit within the specified dimensions in
-// terminal cells, maintaining the aspect ratio.
-func fitImage(id string, img image.Image, cs CellSize, cols, rows int) image.Image {
+// terminal cells, maintaining the aspect ratio. It returns the resized image
+// along with its cell footprint, which is <= cols/rows because the fit
+// preserves aspect ratio.
+func fitImage(id string, img image.Image, cs CellSize, cols, rows int) (image.Image, int, int) {
 	if img == nil {
-		return nil
+		return nil, cols, rows
 	}
 
 	key := imageKey{id: id, cols: cols, rows: rows}
@@ -88,11 +95,11 @@ func fitImage(id string, img image.Image, cs CellSize, cols, rows int) image.Ima
 	cached, ok := cachedImages[key]
 	cachedMutex.RUnlock()
 	if ok {
-		return cached.img
+		return cached.img, cached.fitCols, cached.fitRows
 	}
 
 	if cs.Width == 0 || cs.Height == 0 {
-		return img
+		return img, cols, rows
 	}
 
 	maxWidth := cols * cs.Width
@@ -100,15 +107,25 @@ func fitImage(id string, img image.Image, cs CellSize, cols, rows int) image.Ima
 
 	img = imaging.Fit(img, maxWidth, maxHeight, imaging.Lanczos)
 
+	b := img.Bounds()
+	fitCols := min(cols, ceilDiv(b.Dx(), cs.Width))
+	fitRows := min(rows, ceilDiv(b.Dy(), cs.Height))
+
 	cachedMutex.Lock()
 	cachedImages[key] = cachedImage{
-		img:  img,
-		cols: cols,
-		rows: rows,
+		img:     img,
+		cols:    cols,
+		rows:    rows,
+		fitCols: fitCols,
+		fitRows: fitRows,
 	}
 	cachedMutex.Unlock()
 
-	return img
+	return img, fitCols, fitRows
+}
+
+func ceilDiv(a, b int) int {
+	return (a + b - 1) / b
 }
 
 // HasTransmitted checks if the image with the given ID has already been
@@ -138,33 +155,31 @@ func (e Encoding) Transmit(id string, img image.Image, cs CellSize, cols, rows i
 		return nil
 	}
 
-	cmd := func() tea.Msg {
-		if e != EncodingKitty {
-			cachedMutex.Lock()
-			cachedImages[key] = cachedImage{
-				img:  img,
-				cols: cols,
-				rows: rows,
-			}
-			cachedMutex.Unlock()
+	// Cache synchronously so the render in the same update cycle resolves
+	// HasTransmitted; only the terminal write stays in the returned command.
+	fitted, fitCols, fitRows := fitImage(id, img, cs, cols, rows)
+
+	if e != EncodingKitty {
+		return func() tea.Msg {
 			return TransmittedMsg{ID: key.ID()}
 		}
+	}
 
+	return func() tea.Msg {
 		var buf bytes.Buffer
-		img := fitImage(id, img, cs, cols, rows)
-		bounds := img.Bounds()
+		bounds := fitted.Bounds()
 		imgWidth := bounds.Dx()
 		imgHeight := bounds.Dy()
 		imgID := int(key.Hash())
-		if err := kitty.EncodeGraphics(&buf, img, &kitty.Options{
+		if err := kitty.EncodeGraphics(&buf, fitted, &kitty.Options{
 			ID:               imgID,
 			Action:           kitty.TransmitAndPut,
 			Transmission:     kitty.Direct,
 			Format:           kitty.RGBA,
 			ImageWidth:       imgWidth,
 			ImageHeight:      imgHeight,
-			Columns:          cols,
-			Rows:             rows,
+			Columns:          fitCols,
+			Rows:             fitRows,
 			VirtualPlacement: true,
 			Quite:            1,
 			Chunk:            true,
@@ -184,8 +199,6 @@ func (e Encoding) Transmit(id string, img image.Image, cs CellSize, cols, rows i
 
 		return tea.RawMsg{Msg: buf.String()}
 	}
-
-	return cmd
 }
 
 // Render renders the given image within the specified dimensions using the
@@ -238,7 +251,11 @@ func (e Encoding) Render(id string, cols, rows int) string {
 		canvas.Paint()
 		return strings.TrimSpace(canvas.GetResult())
 	case EncodingKitty:
-		// Build Kitty graphics unicode place holders
+		fitCols, fitRows := cached.fitCols, cached.fitRows
+		if fitCols == 0 || fitRows == 0 {
+			fitCols, fitRows = cols, rows
+		}
+
 		var fg color.Color
 		var extra int
 		var r, g, b int
@@ -260,22 +277,17 @@ func (e Encoding) Render(id string, cols, rows int) string {
 		fgStyle := ansi.NewStyle().ForegroundColor(fg).String()
 
 		var buf bytes.Buffer
-		for y := range rows {
-			// As an optimization, we only write the fg color sequence id, and
-			// column-row data once on the first cell. The terminal will handle
-			// the rest.
-			buf.WriteString(fgStyle)
-			buf.WriteRune(kitty.Placeholder)
-			buf.WriteRune(kitty.Diacritic(y))
-			buf.WriteRune(kitty.Diacritic(0))
-			if extra > 0 {
-				buf.WriteRune(kitty.Diacritic(extra))
-			}
-			for x := 1; x < cols; x++ {
+		for y := range fitRows {
+			for x := range fitCols {
 				buf.WriteString(fgStyle)
 				buf.WriteRune(kitty.Placeholder)
+				buf.WriteRune(kitty.Diacritic(y))
+				buf.WriteRune(kitty.Diacritic(x))
+				if extra > 0 {
+					buf.WriteRune(kitty.Diacritic(extra))
+				}
 			}
-			if y < rows-1 {
+			if y < fitRows-1 {
 				buf.WriteByte('\n')
 			}
 		}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -947,6 +947,7 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 
 	// Add messages to chat with linked tool results
 	items := make([]chat.MessageItem, 0, len(msgs)*2)
+	imgCfg := m.imageConfig()
 	for _, msg := range msgPtrs {
 		switch msg.Role {
 		case message.User:
@@ -963,8 +964,24 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 		}
 	}
 
+	for _, item := range items {
+		if toolItem, ok := item.(chat.ToolMessageItem); ok {
+			toolItem.SetImageConfig(imgCfg)
+			if cmd := toolItem.TransmitImage(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+		if userItem, ok := item.(*chat.UserMessageItem); ok {
+			userItem.SetImageConfig(imgCfg)
+			if cmd := userItem.TransmitImages(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+
 	// Load nested tool calls for agent/agentic_fetch tools.
-	m.loadNestedToolCalls(items)
+	nestedCmds := m.loadNestedToolCalls(items)
+	cmds = append(cmds, nestedCmds...)
 
 	// If the user switches between sessions while the agent is working we want
 	// to make sure the animations are shown.
@@ -985,7 +1002,10 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 }
 
 // loadNestedToolCalls recursively loads nested tool calls for agent/agentic_fetch tools.
-func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
+func (m *UI) loadNestedToolCalls(items []chat.MessageItem) []tea.Cmd {
+	var cmds []tea.Cmd
+	imgCfg := m.imageConfig()
+
 	for _, item := range items {
 		nestedContainer, ok := item.(chat.NestedToolContainer)
 		if !ok {
@@ -1025,6 +1045,10 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 					if simplifiable, ok := nestedToolItem.(chat.Compactable); ok {
 						simplifiable.SetCompact(true)
 					}
+					nestedToolItem.SetImageConfig(imgCfg)
+					if cmd := nestedToolItem.TransmitImage(); cmd != nil {
+						cmds = append(cmds, cmd)
+					}
 					nestedTools = append(nestedTools, nestedToolItem)
 				}
 			}
@@ -1035,11 +1059,13 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 		for i, nt := range nestedTools {
 			nestedMessageItems[i] = nt
 		}
-		m.loadNestedToolCalls(nestedMessageItems)
+		nestedCmds := m.loadNestedToolCalls(nestedMessageItems)
+		cmds = append(cmds, nestedCmds...)
 
 		// Set nested tools on the parent.
 		nestedContainer.SetNestedTools(nestedTools)
 	}
+	return cmds
 }
 
 // appendSessionMessage appends a new message to the current session in the chat
@@ -1057,7 +1083,14 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 	case message.User:
 		m.lastUserMessageTime = msg.CreatedAt
 		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
+		imgCfg := m.imageConfig()
 		for _, item := range items {
+			if userItem, ok := item.(*chat.UserMessageItem); ok {
+				userItem.SetImageConfig(imgCfg)
+				if cmd := userItem.TransmitImages(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+			}
 			if animatable, ok := item.(chat.Animatable); ok {
 				if cmd := animatable.StartAnimation(); cmd != nil {
 					cmds = append(cmds, cmd)
@@ -1101,6 +1134,9 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 			}
 			if toolMsgItem, ok := toolItem.(chat.ToolMessageItem); ok {
 				toolMsgItem.SetResult(&tr)
+				if cmd := toolMsgItem.TransmitImage(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 				if m.chat.Follow() {
 					if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
 						cmds = append(cmds, cmd)
@@ -1178,7 +1214,9 @@ func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
 			}
 		}
 		if existingToolItem == nil {
-			items = append(items, chat.NewToolMessageItem(m.com.Styles, msg.ID, tc, nil, false))
+			item := chat.NewToolMessageItem(m.com.Styles, msg.ID, tc, nil, false)
+			item.SetImageConfig(m.imageConfig())
+			items = append(items, item)
 		}
 	}
 
@@ -1256,6 +1294,7 @@ func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.
 		if !found {
 			// Create a new nested tool item.
 			nestedItem := chat.NewToolMessageItem(m.com.Styles, event.Payload.ID, tc, nil, false)
+			nestedItem.SetImageConfig(m.imageConfig())
 			if simplifiable, ok := nestedItem.(chat.Compactable); ok {
 				simplifiable.SetCompact(true)
 			}
@@ -1273,6 +1312,9 @@ func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.
 		for _, nestedTool := range nestedTools {
 			if nestedTool.ToolCall().ID == tr.ToolCallID {
 				nestedTool.SetResult(&tr)
+				if cmd := nestedTool.TransmitImage(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 				break
 			}
 		}
@@ -2491,6 +2533,31 @@ func (m *UI) currentModelSupportsImages() bool {
 	return model != nil && model.SupportsImages
 }
 
+// imageConfig returns an ImageConfig for inline image rendering if the terminal
+// supports it, or nil otherwise.
+func (m *UI) imageConfig() *chat.ImageConfig {
+	if !m.caps.SupportsKittyGraphics() {
+		return nil
+	}
+	cellW, cellH := m.caps.CellSize()
+	if cellW == 0 || cellH == 0 {
+		return nil
+	}
+	_, isTmux := m.caps.Env.LookupEnv("TMUX")
+
+	maxCols := min(80, m.caps.Columns-10)
+	maxRows := min(20, m.caps.Rows/3)
+
+	return &chat.ImageConfig{
+		Encoding:   fimage.EncodingKitty,
+		CellWidth:  cellW,
+		CellHeight: cellH,
+		Tmux:       isTmux,
+		MaxCols:    maxCols,
+		MaxRows:    maxRows,
+	}
+}
+
 // toggleCompactMode toggles compact mode between uiChat and uiChatCompact states.
 func (m *UI) toggleCompactMode() tea.Cmd {
 	m.forceCompactMode = !m.forceCompactMode
@@ -3557,8 +3624,8 @@ func (m *UI) handleFilePathPaste(path string) tea.Cmd {
 		if fileInfo.IsDir() {
 			return util.ReportWarn("Cannot attach a directory")
 		}
-		if fileInfo.Size() > common.MaxAttachmentSize {
-			return util.ReportWarn("File is too big (>5mb)")
+		if fileInfo.Size() > common.MaxImageAttachmentSize {
+			return util.ReportWarn("Image too large to attach")
 		}
 
 		content, err := os.ReadFile(path)
@@ -3583,14 +3650,14 @@ func (m *UI) handleFilePathPaste(path string) tea.Cmd {
 // interpreting clipboard text as a file path.
 func (m *UI) pasteImageFromClipboard() tea.Msg {
 	imageData, err := readClipboard(clipboardFormatImage)
-	if int64(len(imageData)) > common.MaxAttachmentSize {
-		return util.InfoMsg{
-			Type: util.InfoTypeError,
-			Msg:  "File too large, max 5MB",
+	if err == nil && len(imageData) > 0 {
+		if int64(len(imageData)) > common.MaxImageAttachmentSize {
+			return util.InfoMsg{
+				Type: util.InfoTypeError,
+				Msg:  "Image too large to attach",
+			}
 		}
-	}
-	name := fmt.Sprintf("paste_%d.png", m.pasteIdx())
-	if err == nil {
+		name := fmt.Sprintf("paste_%d.png", m.pasteIdx())
 		return message.Attachment{
 			FilePath: name,
 			FileName: name,
@@ -3601,13 +3668,13 @@ func (m *UI) pasteImageFromClipboard() tea.Msg {
 
 	textData, textErr := readClipboard(clipboardFormatText)
 	if textErr != nil || len(textData) == 0 {
-		return nil // Clipboard is empty or does not contain an image
+		return util.NewInfoMsg("No image found in clipboard")
 	}
 
 	path := strings.TrimSpace(string(textData))
 	path = strings.ReplaceAll(path, "\\ ", " ")
 	if _, statErr := os.Stat(path); statErr != nil {
-		return nil // Clipboard does not contain an image or valid file path
+		return util.NewInfoMsg("No image found in clipboard")
 	}
 
 	lowerPath := strings.ToLower(path)
@@ -3629,10 +3696,10 @@ func (m *UI) pasteImageFromClipboard() tea.Msg {
 			Msg:  fmt.Sprintf("Unable to read file: %v", statErr),
 		}
 	}
-	if fileInfo.Size() > common.MaxAttachmentSize {
+	if fileInfo.Size() > common.MaxImageAttachmentSize {
 		return util.InfoMsg{
 			Type: util.InfoTypeError,
-			Msg:  "File too large, max 5MB",
+			Msg:  "Image too large to attach",
 		}
 	}
 


### PR DESCRIPTION
Attachments & tool calls can render images when the terminal environment supports it

<img width="787" height="471" alt="image" src="https://github.com/user-attachments/assets/452e41d8-674d-4e14-9d3d-efb2c79b1112" />

<img width="1350" height="594" alt="CleanShot 2026-06-18 at 11  44 38@2x" src="https://github.com/user-attachments/assets/11a8dc57-04c3-47a9-bdd1-47f7f1c3fc50" />
